### PR TITLE
feat: add server channels for dice results

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -15,7 +15,9 @@ Add library scripts to your HTML :
 Then create client instance :
 
 ```javascript
-var diceRoller = new DiceIO({ /* optional configuration object */ });
+var diceRoller = new DiceIO({
+  'channel': 'acme123', // "channel" configuration option is recommended
+});
 
 diceRoller
   .setNickname('Frodo')
@@ -40,6 +42,7 @@ diceRoller.roll('1d6');
 
 | Name | Type | Description |
 | ---- | :--: | ----------- |
+| channel | String | Set server channel name. Must be at least three __lowercase alphanumeric__ characters. (default is none) |
 | connect | Boolean | Set this option to `true` to automatically connect to server. (default is `false`) |
 | engine | String | Set engine used by server to roll dice formula. (default is none) |
 | historyOnConnect | Boolean | Set this option to `false` to not get dice roll history after (re)connect to server. (default is `true`) |

--- a/docs/miro.md
+++ b/docs/miro.md
@@ -32,7 +32,10 @@ Finally, click on __"Install app and get OAuth Token"__ button and choose the te
 
 ![app settings](miro-app.png)
 
-Note: this web plugin does not access to board, it only get the name of current logged in user to setup the dice roller nickname.
+Note: this web plugin does not access to boards, it only get :
+
+* the name of current logged in user to setup the dice roller nickname
+* the team account id to setup the dice roller channel name
 
 ## Usage
 

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
     <script>
      (function () {
         var diceRoller = new DiceIO({
+          channel: 'demo',
           // connect: true,
           // historyOnConnect: false,
           // nickname: 'Frodo',

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -4,6 +4,7 @@ import socketIO from 'socket.io-client'
 import {random, isFunction} from './utils'
 import engines from '../server/engines'
 import eventNames from '../server/event-names'
+import { isValid as isValidChannel } from '../server/channel'
 
 export default class DiceRoller {
 
@@ -43,6 +44,10 @@ export default class DiceRoller {
     // Fast & dirty configuration validation
     if (Object.prototype.hasOwnProperty.call(config, 'nickname') && (config.nickname + '').length < 1) {
       this._throwConfigError('nickname')
+    }
+
+    if (config.channel && !isValidChannel(config.channel)) {
+      this._throwConfigError('channel')
     }
 
     if (config.engine && !engines.has(config.engine)) {
@@ -162,12 +167,14 @@ export default class DiceRoller {
 
   getHistory(length) {
     this.connected && this._socket.emit(eventNames.HISTORY, {
+      channel: this._cfg.channel,
       length: length
     })
   }
 
   roll(formula, scope) {
     this.connected && this._socket.emit(eventNames.ROLL, {
+      channel: this._cfg.channel,
       engine: this._cfg.engine,
       formula: formula,
       nickname: this._cfg.nickname,

--- a/src/miro/plugin.js
+++ b/src/miro/plugin.js
@@ -5,27 +5,38 @@ import MiroPluginApp from './miro-plugin-app'
 
 /* global DiceIO, miro */
 
+function startApp(nickname, channel) {
+  // Create dice roller client instance
+  let pathname = window.location.pathname.replace(/miro\/sidebar\.html$/gi, '')
+  let diceRoller = new DiceIO({
+    channel: channel,
+    nickname: nickname,
+    serverUrl: window.location.origin,
+    socketOptions: { path: pathname + 'socket.io' },
+  })
+
+  // Start Miro web plugin application
+  let app = new MiroPluginApp(diceRoller) // eslint-disable-line no-unused-vars
+}
+
 miro.onReady(() => {
-    // Create dice roller client instance
-    let pathname = window.location.pathname.replace(/miro\/sidebar\.html$/gi, '')
-    let diceRoller = new DiceIO({
-        serverUrl: window.location.origin,
-        socketOptions: { path: pathname + 'socket.io' },
+  // Attempt to get current user name (dice roller nickname)
+  miro.currentUser.getId()
+    .then((id) => {
+      fetch('https://miro.com/api/v1/users/' + id)
+        .then(response => response.json())
+        .then(data => {
+          // Attempt to get team account id (dice roller channel)
+          miro.account.get()
+            .then((account) => {
+              startApp(data.name, 'miro' + account.id)
+            })
+            .catch(e => {
+              console.log('[Dice Roller] Failed to get team account id', e)
+            })
+        })
+        .catch(e => {
+          console.log('[Dice Roller] Failed to get current user nickname', e)
+        })
     })
-
-    // Attempt to get current user nickname
-    miro.currentUser.getId()
-      .then((id) => {
-        fetch('https://miro.com/api/v1/users/' + id)
-          .then(response => response.json())
-          .then(data => {
-            diceRoller.setNickname(data.name)
-          })
-          .catch(e => {
-            console.log('Failed to get user nickname', e)
-          })
-      })
-
-    // Start Miro web plugin application
-    let app = new MiroPluginApp(diceRoller) // eslint-disable-line no-unused-vars
 })

--- a/src/server/channel.js
+++ b/src/server/channel.js
@@ -1,0 +1,15 @@
+// Server channel
+
+function isValid(channel) {
+  // At least three lowercase alphanumeric characters
+  return (channel !== undefined) && /^([a-z0-9]{3,})$/.test(channel)
+}
+
+function resolve(data, fallback) {
+  // Fallback to default channel if undefined or invalid
+  return isValid(data.channel) ? data.channel : fallback
+}
+
+exports.isValid = isValid
+
+exports.resolve = resolve

--- a/src/server/dice-io.js
+++ b/src/server/dice-io.js
@@ -1,5 +1,6 @@
 // DiceIO
 
+const channel = require('./channel')
 const crypto = require('crypto')
 const engines = require('./engines')
 const eventNames = require('./event-names')
@@ -8,24 +9,60 @@ const makeEngine = require('./engines/factory')
 
 function DiceIO(io, config) {
   this._cfg = config
-  this._history = new History(config.historyLength)
+  this._histories = {}
   io.on(eventNames.CONNECT, (socket) => {
     console.log('[ %s ] connected', socket.id)
     socket
       .on(eventNames.DISCONNECT, () => console.log('[ %s ] disconnected', socket.id))
       .on(eventNames.HISTORY, (data) => {
         var length = data && data.length || 0
-        socket.emit(eventNames.HISTORY, this.history(length))
+        this._setupChannel(socket, data)
+        socket.emit(eventNames.HISTORY, this.history(socket.diceioChannel).get(length))
       })
       .on(eventNames.ROLL, (data) => {
+        this._setupChannel(socket, data)
         var result = this.roll(data)
+
         if (result.error) {
           socket.emit(eventNames.ERROR, result)
         } else {
-          io.emit(eventNames.ROLL, result)
+          this.history(socket.diceioChannel).expireIn(this._cfg.historyExpiry).push(result)
+          io.to(socket.diceioChannel).emit(eventNames.ROLL, result)
         }
       })
   })
+  this._startHistoryGC(this._cfg.historyInterval)
+}
+
+DiceIO.prototype._setupChannel = function (socket, data) {
+  // Check if already setup
+  if (socket.diceioChannel) {
+    return socket
+  }
+
+  // Setup channel
+  socket.diceioChannel = channel.resolve(data, this._cfg.channel)
+  socket.join(socket.diceioChannel)
+
+  return socket
+}
+
+DiceIO.prototype._startHistoryGC = function (delay) {
+  this._hgcInterval = setInterval(() => { this._performHistoryGC() }, delay)
+}
+
+DiceIO.prototype._performHistoryGC = function () {
+  for (const channel in this._histories) {
+    if (this._histories[channel].expired()) {
+      delete this._histories[channel]
+      console.log('%s channel history has expired', channel)
+    }
+  }
+}
+
+DiceIO.prototype._stopHistoryGC = function () {
+  this._hgcInterval && clearInterval(this._hgcInterval)
+  delete this._hgcInterval
 }
 
 DiceIO.prototype.uuid = function () {
@@ -38,25 +75,27 @@ DiceIO.prototype.resolveEngine = function (engine) {
   return engines.has(engine) ? engine : this._cfg.engine
 }
 
-DiceIO.prototype.history = function (length) {
-  return this._history.get(length)
+DiceIO.prototype.history = function (channel) {
+  if (!this._histories[channel]) {
+    this._histories[channel] = new History(this._cfg.historyLength)
+  }
+
+  return this._histories[channel]
 }
 
 DiceIO.prototype.roll = function (data) {
   var engineName = this.resolveEngine(data.engine)
   try {
     var diceRoller = makeEngine(engineName)
-    var result = {
+
+    return {
       id: this.uuid(),
       nickname: data.nickname,
       roll: diceRoller.roll(data.formula),
       timestamp: Date.now(),
     }
-
-    this._history.push(result)
-
-    return result
   } catch (error) {
+
     return {
       error: error,
       message: 'Roll has failed',

--- a/src/server/history.js
+++ b/src/server/history.js
@@ -1,6 +1,7 @@
 // History
 
 function History(maxLength) {
+  this._expireAt = false
   this._maxLength = maxLength
   this.clear()
 }
@@ -19,6 +20,16 @@ History.prototype.push = function (item) {
   }
 
   return this._items.push(item)
+}
+
+History.prototype.expireIn = function (milliseconds) {
+  this._expireAt = Date.now() + milliseconds
+
+  return this
+}
+
+History.prototype.expired = function () {
+  return this._expireAt && Date.now() >= this._expireAt
 }
 
 exports = module.exports = History

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -15,8 +15,11 @@ exports.defaultConfig = function () {
   return {
     host: '127.0.0.1',
     port: 8080,
+    channel: 'diceiodef',
     engine: engines.RPG_DICE_ROLLER,
+    historyInterval: 60000,    // 1 minute
     historyLength: 50,
+    historyExpiry: 2592000000, // 30 days
   }
 }
 


### PR DESCRIPTION
It adds a new `channel` client configuration option to set server channel name for roll results. _(ie: several groups of users using same dice.io server)_

It set `demo` channel in demo application.

It use team account id to automatically setup channel name in Miro Web plugin.
